### PR TITLE
feat: Alteração de restrição de FKs

### DIFF
--- a/docs/database-schema.txt
+++ b/docs/database-schema.txt
@@ -79,3 +79,18 @@ CREATE TABLE "KidReligionInformation" (
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('20201023011235_KidReligionInformation', '3.1.9');
 
+ALTER TABLE "Kid" DROP CONSTRAINT "FK_Kid_Family_FamilyId";
+
+ALTER TABLE "KidReligionInformation" DROP CONSTRAINT "FK_KidReligionInformation_Kid_Id";
+
+ALTER TABLE "Kinship" DROP CONSTRAINT "FK_Kinship_Family_FamilyId";
+
+ALTER TABLE "Kid" ADD CONSTRAINT "FK_Kid_Family_FamilyId" FOREIGN KEY ("FamilyId") REFERENCES "Family" ("Id") ON DELETE RESTRICT;
+
+ALTER TABLE "KidReligionInformation" ADD CONSTRAINT "FK_KidReligionInformation_Kid_Id" FOREIGN KEY ("Id") REFERENCES "Kid" ("Id") ON DELETE RESTRICT;
+
+ALTER TABLE "Kinship" ADD CONSTRAINT "FK_Kinship_Family_FamilyId" FOREIGN KEY ("FamilyId") REFERENCES "Family" ("Id") ON DELETE RESTRICT;
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20201029000807_FksRestriction', '3.1.9');
+

--- a/docs/database-schema.txt
+++ b/docs/database-schema.txt
@@ -94,3 +94,10 @@ ALTER TABLE "Kinship" ADD CONSTRAINT "FK_Kinship_Family_FamilyId" FOREIGN KEY ("
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('20201029000807_FksRestriction', '3.1.9');
 
+ALTER TABLE "KidReligionInformation" DROP CONSTRAINT "FK_KidReligionInformation_Kid_Id";
+
+ALTER TABLE "KidReligionInformation" ADD CONSTRAINT "FK_KidReligionInformation_Kid_Id" FOREIGN KEY ("Id") REFERENCES "Kid" ("Id") ON DELETE CASCADE;
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20201029011449_UpdateFkRestrictToCascadeFromTableKidReligion', '3.1.9');
+

--- a/src/backend/Family.Manager/Family.Manager.API/Startup.cs
+++ b/src/backend/Family.Manager/Family.Manager.API/Startup.cs
@@ -23,10 +23,10 @@ namespace Family.Manager.API
             services.RegisterSwagger();
             services.RegisterServices();
             services.AddAutoMapper(typeof(Startup));
+            services.AddGlobalExceptionHandlerMiddleware();
             services.AddControllers()
                 .AddNewtonsoftJson(options =>
                 {
-                    //options.SerializerSettings.ContractResolver = new LowerCaseContractResolver();
                     options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
                 });
         }
@@ -36,6 +36,10 @@ namespace Family.Manager.API
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseGlobalExceptionHandlerMiddleware();
             }
 
             app.UseHttpsRedirection();

--- a/src/backend/Family.Manager/Family.Manager.Infrastructure/Extensions/GlobalExceptionHandlerMiddlewareExtensions.cs
+++ b/src/backend/Family.Manager/Family.Manager.Infrastructure/Extensions/GlobalExceptionHandlerMiddlewareExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Family.Manager.Infrastructure.Middleware;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Family.Manager.Infrastructure.Extensions
+{
+	public static class GlobalExceptionHandlerMiddlewareExtensions
+	{
+		public static IServiceCollection AddGlobalExceptionHandlerMiddleware(this IServiceCollection services)
+		{
+			return services.AddTransient<GlobalExceptionHandlerMiddleware>();
+		}
+
+		public static void UseGlobalExceptionHandlerMiddleware(this IApplicationBuilder app)
+		{
+			app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
+		}
+	}
+}

--- a/src/backend/Family.Manager/Family.Manager.Infrastructure/Mappings/KidConfiguration.cs
+++ b/src/backend/Family.Manager/Family.Manager.Infrastructure/Mappings/KidConfiguration.cs
@@ -29,7 +29,7 @@ namespace Family.Manager.Infrastructure.Mappings
             builder.HasOne(k => k.KidReligionInformation)
                    .WithOne(kr => kr.Kid)
                    .HasForeignKey<KidReligionInformation>(kr => kr.Id)
-                   .OnDelete(DeleteBehavior.Restrict);
+                   .OnDelete(DeleteBehavior.Cascade);
         }
     }
 }

--- a/src/backend/Family.Manager/Family.Manager.Infrastructure/Mappings/KidConfiguration.cs
+++ b/src/backend/Family.Manager/Family.Manager.Infrastructure/Mappings/KidConfiguration.cs
@@ -24,12 +24,12 @@ namespace Family.Manager.Infrastructure.Mappings
 
             builder.HasOne(k => k.Family)
                    .WithMany(f => f.Kids)
-                   .OnDelete(DeleteBehavior.Cascade);
+                   .OnDelete(DeleteBehavior.Restrict);
 
             builder.HasOne(k => k.KidReligionInformation)
                    .WithOne(kr => kr.Kid)
                    .HasForeignKey<KidReligionInformation>(kr => kr.Id)
-                   .OnDelete(DeleteBehavior.Cascade);
+                   .OnDelete(DeleteBehavior.Restrict);
         }
     }
 }

--- a/src/backend/Family.Manager/Family.Manager.Infrastructure/Mappings/KinshipConfiguration.cs
+++ b/src/backend/Family.Manager/Family.Manager.Infrastructure/Mappings/KinshipConfiguration.cs
@@ -21,7 +21,7 @@ namespace Family.Manager.Infrastructure.Mappings
 
             builder.HasOne(k => k.Family)
                    .WithMany(f => f.Kinships)
-                   .OnDelete(DeleteBehavior.Cascade);
+                   .OnDelete(DeleteBehavior.Restrict);
         }
     }
 }

--- a/src/backend/Family.Manager/Family.Manager.Infrastructure/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/src/backend/Family.Manager/Family.Manager.Infrastructure/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Family.Manager.Infrastructure.Middleware
+{
+    public class GlobalExceptionHandlerMiddleware : IMiddleware
+    {
+        private readonly ILogger<GlobalExceptionHandlerMiddleware> _logger;
+
+        public GlobalExceptionHandlerMiddleware(ILogger<GlobalExceptionHandlerMiddleware> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        {
+            try
+            {
+                await next(context);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Unexpected error: {ex}");
+                await HandleExceptionAsync(context, ex);
+            }
+        }
+
+        private static Task HandleExceptionAsync(HttpContext context, Exception exception)
+        {
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+
+            var json = new
+            {
+                status_code = context.Response.StatusCode,
+                message = "An interval server error has occured.",
+                detailed = exception.Message
+            };
+
+            return context.Response.WriteAsync(JsonConvert.SerializeObject(json));
+        }
+    }
+}

--- a/src/backend/Family.Manager/Family.Manager.Infrastructure/Migrations/20201029000807_FksRestriction.Designer.cs
+++ b/src/backend/Family.Manager/Family.Manager.Infrastructure/Migrations/20201029000807_FksRestriction.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Family.Manager.Infrastructure.Configurations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Family.Manager.Infrastructure.Migrations
 {
     [DbContext(typeof(FamilyContext))]
-    partial class FamilyContextModelSnapshot : ModelSnapshot
+    [Migration("20201029000807_FksRestriction")]
+    partial class FksRestriction
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/Family.Manager/Family.Manager.Infrastructure/Migrations/20201029000807_FksRestriction.cs
+++ b/src/backend/Family.Manager/Family.Manager.Infrastructure/Migrations/20201029000807_FksRestriction.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Family.Manager.Infrastructure.Migrations
+{
+    public partial class FksRestriction : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Kid_Family_FamilyId",
+                table: "Kid");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_KidReligionInformation_Kid_Id",
+                table: "KidReligionInformation");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Kinship_Family_FamilyId",
+                table: "Kinship");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Kid_Family_FamilyId",
+                table: "Kid",
+                column: "FamilyId",
+                principalTable: "Family",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_KidReligionInformation_Kid_Id",
+                table: "KidReligionInformation",
+                column: "Id",
+                principalTable: "Kid",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Kinship_Family_FamilyId",
+                table: "Kinship",
+                column: "FamilyId",
+                principalTable: "Family",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Kid_Family_FamilyId",
+                table: "Kid");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_KidReligionInformation_Kid_Id",
+                table: "KidReligionInformation");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Kinship_Family_FamilyId",
+                table: "Kinship");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Kid_Family_FamilyId",
+                table: "Kid",
+                column: "FamilyId",
+                principalTable: "Family",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_KidReligionInformation_Kid_Id",
+                table: "KidReligionInformation",
+                column: "Id",
+                principalTable: "Kid",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Kinship_Family_FamilyId",
+                table: "Kinship",
+                column: "FamilyId",
+                principalTable: "Family",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/backend/Family.Manager/Family.Manager.Infrastructure/Migrations/20201029011449_UpdateFkRestrictToCascadeFromTableKidReligion.Designer.cs
+++ b/src/backend/Family.Manager/Family.Manager.Infrastructure/Migrations/20201029011449_UpdateFkRestrictToCascadeFromTableKidReligion.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Family.Manager.Infrastructure.Configurations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Family.Manager.Infrastructure.Migrations
 {
     [DbContext(typeof(FamilyContext))]
-    partial class FamilyContextModelSnapshot : ModelSnapshot
+    [Migration("20201029011449_UpdateFkRestrictToCascadeFromTableKidReligion")]
+    partial class UpdateFkRestrictToCascadeFromTableKidReligion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/Family.Manager/Family.Manager.Infrastructure/Migrations/20201029011449_UpdateFkRestrictToCascadeFromTableKidReligion.cs
+++ b/src/backend/Family.Manager/Family.Manager.Infrastructure/Migrations/20201029011449_UpdateFkRestrictToCascadeFromTableKidReligion.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Family.Manager.Infrastructure.Migrations
+{
+    public partial class UpdateFkRestrictToCascadeFromTableKidReligion : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_KidReligionInformation_Kid_Id",
+                table: "KidReligionInformation");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_KidReligionInformation_Kid_Id",
+                table: "KidReligionInformation",
+                column: "Id",
+                principalTable: "Kid",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_KidReligionInformation_Kid_Id",
+                table: "KidReligionInformation");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_KidReligionInformation_Kid_Id",
+                table: "KidReligionInformation",
+                column: "Id",
+                principalTable: "Kid",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}


### PR DESCRIPTION
**O que foi feito?**
Alterei a restrição ao deletar um registro que possua uma FK para a opção `Restrict`, pois com ela não vamos poder excluir um registro que possua dependências em outras tabelas. Logo, devemos excluir primeiro as dependências filhas para depois excluir o pai.