### PR TITLE
feat: Correção de consulta de uma única família

### DIFF
--- a/src/backend/Family.Manager/Family.Manager.API/Controllers/FamilyController.cs
+++ b/src/backend/Family.Manager/Family.Manager.API/Controllers/FamilyController.cs
@@ -47,11 +47,11 @@ namespace Family.Manager.API.Controllers
 
         [HttpGet]
         [Route("{familyId}")]
-        [ProducesResponseType(typeof(IEnumerable<FamilyWithKidsAndKinshipsResponse>), StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetAllFamiliesAsync(string familyId)
+        [ProducesResponseType(typeof(FamilyWithKidsAndKinshipsResponse), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetFamilyAsync(string familyId)
         {
-            var families = await _familyRepository.GetFamilyWithKidsAndKinshipsAsync(Guid.Parse(familyId));
-            var result = _mapper.Map<IEnumerable<FamilyWithKidsAndKinshipsResponse>>(families);
+            var family = await _familyRepository.GetFamilyWithKidsAndKinshipsAsync(Guid.Parse(familyId));
+            var result = _mapper.Map<FamilyWithKidsAndKinshipsResponse>(family);
             return Ok(result);
         }
 

--- a/src/backend/Family.Manager/Family.Manager.Infrastructure/DataProviders/Repository/FamilyRepository.cs
+++ b/src/backend/Family.Manager/Family.Manager.Infrastructure/DataProviders/Repository/FamilyRepository.cs
@@ -22,7 +22,7 @@ namespace Family.Manager.Infrastructure.DataProviders.Repository
             return await _context.Families.AsNoTracking().ToListAsync();
         }
 
-        public async Task<IEnumerable<Domain.Entities.Family>> GetFamilyWithKidsAndKinshipsAsync(Guid familyId)
+        public async Task<Domain.Entities.Family> GetFamilyWithKidsAndKinshipsAsync(Guid familyId)
         {
             return await _context.Families
                 .AsNoTracking()
@@ -30,7 +30,7 @@ namespace Family.Manager.Infrastructure.DataProviders.Repository
                 .Include(f => f.Kinships)
                 .Include(f => f.Kids)
                 .ThenInclude(k => k.KidReligionInformation)
-                .ToListAsync();
+                .SingleOrDefaultAsync();
         }
     }
 }

--- a/src/backend/Family.Manager/Family.Manager.Infrastructure/DataProviders/Repository/IFamilyRepository.cs
+++ b/src/backend/Family.Manager/Family.Manager.Infrastructure/DataProviders/Repository/IFamilyRepository.cs
@@ -7,7 +7,7 @@ namespace Family.Manager.Infrastructure.DataProviders.Repository
 {
     public interface IFamilyRepository : IRepositoryBase<Domain.Entities.Family, Guid>
     {
-        Task<IEnumerable<Domain.Entities.Family>> GetFamilyWithKidsAndKinshipsAsync(Guid familyId);
         Task<IEnumerable<Domain.Entities.Family>> GetFamiliesDescriptionAsync();
+        Task<Domain.Entities.Family> GetFamilyWithKidsAndKinshipsAsync(Guid familyId);
     }
 }


### PR DESCRIPTION
**O que foi feito?**

Endpoint estava retornando uma lista de famílias ao invés de apenas um único registro. Com esse ajuste será possível visualizarmos o detalhe da família no frontend.